### PR TITLE
Adding transitional C++ version, to be used as a base for CUDA version

### DIFF
--- a/cxx/data.cpp
+++ b/cxx/data.cpp
@@ -1,0 +1,10 @@
+#include "data.h"
+
+#include <stdio.h>
+
+// fields that hold the solution
+double *data::x_new = NULL, *data::x_old = NULL; // 2d
+double *data::bndN = NULL, *data::bndE = NULL, *data::bndS = NULL, *data::bndW = NULL;
+
+data::discretization_t data::options;
+

--- a/cxx/data.h
+++ b/cxx/data.h
@@ -1,0 +1,27 @@
+#ifndef DATA_H
+#define DATA_H
+
+namespace data
+{
+	// define some helper types that can be used to pass simulation
+	// data around without haveing to pass individual parameters
+	struct discretization_t
+	{
+		int nx;       // x dimension
+		int ny;       // y dimension
+		int nt;       // number of time steps
+		int N;        // total number of grid points
+		double dt;    // time step size
+		double dx;    // distance between grid points
+		double alpha; // dx^2/(D*dt)
+	};
+
+	// fields that hold the solution
+	extern double *x_new, *x_old; // 2d
+	extern double *bndN, *bndE, *bndS, *bndW; // 1d
+	
+	extern discretization_t options;
+}
+
+#endif // DATA_H
+

--- a/cxx/linalg.cpp
+++ b/cxx/linalg.cpp
@@ -1,0 +1,252 @@
+// linear algebra subroutines
+// Ben Cumming @ CSCS
+
+#include "linalg.h"
+#include "operators.h"
+#include "stats.h"
+
+#include <math.h>
+#include <stdio.h>
+
+bool linalg::cg_initialized = false;
+double *linalg::r = NULL, *linalg::Ap = NULL, *linalg::p = NULL;
+double *linalg::Fx = NULL, *linalg::Fxold = NULL, *linalg::v = NULL, *linalg::xold = NULL; // 1d
+
+using namespace operators;
+using namespace stats;
+
+// initialize temporary storage fields used by the cg solver
+// I do this here so that the fields are persistent between calls
+// to the CG solver. This is useful if we want to avoid malloc/free calls
+// on the device for the OpenACC implementation (feel free to suggest a better
+// method for doing this)
+void linalg::cg_init(const int N)
+{
+	Ap = new double[N];
+	r = new double[N];
+	p = new double[N];
+	Fx = new double[N];
+	Fxold = new double[N];
+	v = new double[N];
+	xold = new double[N];
+	
+	cg_initialized = true;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//  blas level 1 reductions
+////////////////////////////////////////////////////////////////////////////////
+
+// computes the inner product of x and y
+// x and y are vectors on length N
+double linalg::ss_dot(const double* x, const double* y, const int N)
+{
+	double result = 0;
+	for (int i = 0; i < N; i++)
+		result += x[i] * y[i];
+
+	// record the number of floating point oporations
+	flops_blas1 = flops_blas1 + 2 * N;
+	
+	return result;
+}
+
+// computes the 2-norm of x
+// x is a vector on length N
+double linalg::ss_norm2(const double* x, const int N)
+{
+	double result = 0;
+	for (int i = 0; i < N; i++)
+		result += x[i] * x[i];
+
+	result = sqrt(result);
+
+	// record the number of floating point oporations
+	flops_blas1 = flops_blas1 + 2 * N;
+	
+	return result;
+}
+
+// sets entries in a vector to value
+// x is a vector on length N
+// value is th
+void linalg::ss_fill(double* x, const double value, const int N)
+{
+	for (int i = 0; i < N; i++)
+		x[i] = value;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//  blas level 1 vector-vector operations
+////////////////////////////////////////////////////////////////////////////////
+
+// computes y := alpha*x + y
+// x and y are vectors on length N
+// alpha is a scalar
+void linalg::ss_axpy(double* y, const double alpha, const double* x, const int N)
+{
+	for (int i = 0; i < N; i++)
+		y[i] += alpha * x[i];
+
+	// record the number of floating point oporations
+	flops_blas1 = flops_blas1 + 2 * N;
+}
+
+// computes y = x + alpha*(l-r)
+// y, x, l and r are vectors of length N
+// alpha is a scalar
+void linalg::ss_add_scaled_diff(double* y, const double* x, const double alpha,
+	const double* l, const double* r, const int N)
+{
+	for (int i = 0; i < N; i++)
+		y[i] = x[i] + alpha * (l[i] - r[i]);
+
+	// record the number of floating point oporations
+	flops_blas1 = flops_blas1 + 3 * N;
+}
+
+// computes y = alpha*(l-r)
+// y, l and r are vectors of length N
+// alpha is a scalar
+void linalg::ss_scaled_diff(double* y, const double alpha,
+	const double* l, const double* r, const int N)
+{
+	for (int i = 0; i < N; i++)
+		y[i] = alpha * (l[i] - r[i]);
+
+	// record the number of floating point oporations
+	flops_blas1 = flops_blas1 + 2 * N;
+}
+
+// computes y := alpha*x
+// alpha is scalar
+// y and x are vectors on length n
+void linalg::ss_scale(double* y, const double alpha, double* x, const int N)
+{
+	for (int i = 0; i < N; i++)
+		y[i] = alpha * x[i];
+
+	// record the number of floating point oporations
+	flops_blas1 = flops_blas1 + N;
+}
+
+// computes linear combination of two vectors y := alpha*x + beta*z
+// alpha and beta are scalar
+// y, x and z are vectors on length n
+void linalg::ss_lcomb(double* y, const double alpha, double* x, const double beta,
+	const double* z, const int N)
+{
+	for (int i = 0; i < N; i++)
+		y[i] = alpha * x[i] + beta * z[i];
+
+	// record the number of floating point oporations
+	flops_blas1 = flops_blas1 + 3 * N;
+}
+
+// copy one vector into another y := x
+// x and y are vectors of length N
+void linalg::ss_copy(double* y, const double* x, const int N)
+{
+	for (int i = 0; i < N; i++)
+		y[i] = x[i];
+}
+
+// conjugate gradient solver
+// solve the linear system A*x = b for x
+// the matrix A is implicit in the objective function for the diffusion equation
+// the value in x constitute the "first guess" at the solution
+// x(N)
+// ON ENTRY contains the initial guess for the solution
+// ON EXIT  contains the solution
+void linalg::ss_cg(double* x, const double* b, const int maxiters, const double tol, bool* success)
+{
+	data::discretization_t& options = data::options;
+
+	// this is the dimension of the linear system that we are to solve
+	int N = options.N;
+
+	if (!cg_initialized)
+	{
+		printf("INITIALIZING CG STATE\n");
+		cg_init(N);
+	}
+
+	// epslion value use for matrix-vector approximation
+	double eps     = 1.e-8;
+	double eps_inv = 1. / eps;
+
+	// allocate memory for temporary storage
+	ss_fill(Fx,    0.0, N);
+	ss_fill(Fxold, 0.0, N);
+	ss_copy(xold, x, N);
+
+	// matrix vector multiplication is approximated with
+	// A*v = 1/epsilon * ( F(x+epsilon*v) - F(x) )
+	//     = 1/epsilon * ( F(x+epsilon*v) - Fxold )
+	// we compute Fxold at startup
+	// we have to keep x so that we can compute the F(x+exps*v)
+	diffusion(x, Fxold);
+
+	// v = x + epsilon*x
+	ss_scale(v, 1.0 + eps, x, N);
+
+	// Fx = F(v)
+	diffusion(v, Fx);
+
+	// r = b - A*x
+	// where A*x = (Fx-Fxold)/eps
+	ss_add_scaled_diff(r, b, -eps_inv, Fx, Fxold, N);
+
+	// p = r
+	ss_copy(p, r, N);
+
+	// rold = <r,r>
+	double rold = ss_dot(r, r, N), rnew = rold;
+
+	// check for convergence
+	*success = false;
+	if (sqrt(rold) < tol)
+	{
+		*success = true;
+		return;
+	}
+
+	for (int iter = 1; iter <= maxiters; iter++)
+	{
+		// Ap = A*p
+		ss_lcomb(v, 1.0, xold, eps, p, N);
+		diffusion(v, Fx);
+		ss_scaled_diff(Ap, eps_inv, Fx, Fxold, N);
+		
+		// alpha = rold / p'*Ap
+		double alpha = rold / ss_dot(p, Ap, N);
+		
+		// x += alpha*p
+		ss_axpy(x, alpha, p, N);
+		
+		// r -= alpha*Ap
+		ss_axpy(r, -alpha, Ap, N);
+		
+		// find new norm
+		rnew = ss_dot(r, r, N);
+		
+		// test for convergence
+		if (sqrt(rnew) < tol)
+		{
+			*success = true;
+			return;
+		}
+
+		// p = r + rnew.rold * p
+		ss_lcomb(p, 1.0, r, rnew / rold, p, N);
+		
+		rold = rnew;
+	}
+	
+	if (!*success)
+	{
+		fprintf(stderr, "ERROR: CG failed to converge after %d iterations\n", maxiters);
+		fprintf(stderr, "       achived tol = %E, required tol = %E\n", sqrt(rnew), tol);
+	}
+}
+

--- a/cxx/linalg.h
+++ b/cxx/linalg.h
@@ -1,0 +1,85 @@
+// linear algebra subroutines
+// Ben Cumming @ CSCS
+
+#ifndef LINALG_H
+#define LINALG_H
+
+#include "data.h"
+
+namespace linalg
+{
+	extern bool cg_initialized;
+	extern double *r, *Ap, *p, *Fx, *Fxold, *v, *xold; // 1d
+
+	// initialize temporary storage fields used by the cg solver
+	// I do this here so that the fields are persistent between calls
+	// to the CG solver. This is useful if we want to avoid malloc/free calls
+	// on the device for the OpenACC implementation (feel free to suggest a better
+	// method for doing this)
+	void cg_init(const int N);
+
+	////////////////////////////////////////////////////////////////////////////////
+	//  blas level 1 reductions
+	////////////////////////////////////////////////////////////////////////////////
+
+	// computes the inner product of x and y
+	// x and y are vectors on length N
+	double ss_dot(const double* x, const double* y, const int N);
+
+	// computes the 2-norm of x
+	// x is a vector on length N
+	double ss_norm2(const double* x, const int N);
+
+	// sets entries in a vector to value
+	// x is a vector on length N
+	// value is th
+	void ss_fill(double* x, const double value, const int N);
+
+	////////////////////////////////////////////////////////////////////////////////
+	//  blas level 1 vector-vector operations
+	////////////////////////////////////////////////////////////////////////////////
+
+	// computes y := alpha*x + y
+	// x and y are vectors on length N
+	// alpha is a scalar
+	void ss_axpy(double* y, const double alpha, const double* x, const int N);
+
+	// computes y = x + alpha*(l-r)
+	// y, x, l and r are vectors of length N
+	// alpha is a scalar
+	void ss_add_scaled_diff(double* y, const double* x, const double alpha,
+		const double* l, const double* r, const int N);
+
+	// computes y = alpha*(l-r)
+	// y, l and r are vectors of length N
+	// alpha is a scalar
+	void ss_scaled_diff(double* y, const double alpha,
+		const double* l, const double* r, const int N);
+
+	// computes y := alpha*x
+	// alpha is scalar
+	// y and x are vectors on length n
+	void ss_scale(double* y, const double alpha, double* x, const int N);
+
+	// computes linear combination of two vectors y := alpha*x + beta*z
+	// alpha and beta are scalar
+	// y, x and z are vectors on length n
+	void ss_lcomb(double* y, const double alpha, double* x, const double beta,
+		const double* z, const int N);
+
+	// copy one vector into another y := x
+	// x and y are vectors of length N
+	void ss_copy(double* y, const double* x, const int N);
+
+	// conjugate gradient solver
+	// solve the linear system A*x = b for x
+	// the matrix A is implicit in the objective function for the diffusion equation
+	// the value in x constitute the "first guess" at the solution
+	// x(N)
+	// ON ENTRY contains the initial guess for the solution
+	// ON EXIT  contains the solution
+	void ss_cg(double* x, const double* b, const int maxiters, const double tol, bool* success);
+}
+
+#endif // LINALG_H
+

--- a/cxx/main.cpp
+++ b/cxx/main.cpp
@@ -1,0 +1,243 @@
+// ******************************************
+// implicit time stepping implementation of 2D diffusion problem
+// Ben Cumming, CSCS
+// *****************************************
+
+// A small benchmark app that solves the 2D fisher equation using second-order
+// finite differences.
+
+// Syntax: ./main nx ny nt t
+
+#include <math.h>
+#include <omp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "data.h"
+#include "linalg.h"
+#include "operators.h"
+#include "stats.h"
+
+using namespace data;
+using namespace linalg;
+using namespace operators;
+using namespace stats;
+
+// ==============================================================================
+
+// read command line arguments
+static void readcmdline(discretization_t* options, int argc, char* argv[])
+{
+	if (argc != 5)
+	{
+		printf("Usage: main nx ny nt t\n");
+		printf("  nx  number of gridpoints in x-direction\n");
+		printf("  ny  number of gridpoints in y-direction\n");
+		printf("  nt  number of timesteps\n");
+		printf("  t   total time\n");
+		exit(1);
+	}
+
+	// read nx
+	options->nx = atoi(argv[1]);
+	if (options->nx < 1)
+	{
+		fprintf(stderr, "nx must be positive integer\n");
+		exit(-1);
+	}
+
+	// read ny
+	options->ny = atoi(argv[2]);
+	if (options->ny < 1)
+	{
+		fprintf(stderr, "ny must be positive integer\n");
+		exit(-1);
+	}
+
+	// read nt
+	options->nt = atoi(argv[3]);
+	if (options->nt < 1)
+	{
+		fprintf(stderr, "nt must be positive integer\n");
+		exit(-1);
+	}
+	
+	// read total time
+	double t = atof(argv[4]);
+	if (t < 0)
+	{
+		fprintf(stderr, "t must be positive real value\n");
+		exit(-1);
+	}
+
+	// store the parameters
+	options->N = options->nx * options->ny;
+
+	// compute timestep size
+	options->dt = t / options->nt;
+	
+	// compute the distance between grid points
+	// assume that x dimension has length 1.0
+	options->dx = 1. / (options->nx - 1);
+	
+	// set alpha, assume diffusion coefficient D is 1
+	options->alpha = (options->dx * options->dx) / (1. * options->dt);
+}
+
+// ==============================================================================
+
+int main(int argc, char* argv[])
+{
+	// read command line arguments
+	readcmdline(&options, argc, argv);
+	int nx = options.nx;
+	int ny = options.ny;
+	int N  = options.N;
+	int nt = options.nt;
+
+	printf("========================================================================\n");
+	printf("                      Welcome to mini-stencil!\n");
+	printf("mesh :: %d * %d, dx = %f\n", nx, ny, options.dx);
+	printf("time :: %d, time steps from 0 .. %f\n", nt, options.nt * options.dt);
+	printf("========================================================================\n");
+
+	// allocate global fields
+	x_new = new double[nx * ny];
+	x_old = new double[nx * ny];
+	bndN = new double[nx];
+	bndS = new double[nx];
+	bndE = new double[ny];
+	bndW = new double[ny];
+
+	double* b = new double[N];
+	double* deltax = new double[N];
+
+	// set dirichlet boundary conditions to 0 all around
+	memset(bndN, 0, sizeof(double) * nx);
+	memset(bndS, 0, sizeof(double) * nx);
+	memset(bndE, 0, sizeof(double) * ny);
+	memset(bndW, 0, sizeof(double) * ny);
+
+	// set the initial condition
+	// a circle of concentration 0.1 centred at (xdim/4, ydim/4) with radius
+	// no larger than 1/8 of both xdim and ydim
+	memset(x_new, 0, sizeof(double) * nx * ny);
+	double xc = 1.0 / 4.0;
+	double yc = (ny - 1) * options.dx / 4;
+	double radius = fmin(xc, yc) / 2.0;
+	for (int j = 0; j < ny; j++)
+	{
+		double y = (j - 1) * options.dx;
+		for (int i = 0; i < nx; i++)
+		{
+			double x = (i - 1) * options.dx;
+			if ((x - xc) * (x - xc) + (y - yc) * (y - yc) < radius * radius)
+				((double(*)[nx])x_new)[j][i] = 0.1;
+		}
+	}
+
+	double time_in_bcs = 0.0;
+	double time_in_diff = 0.0;
+	flops_bc = 0;
+	flops_diff = 0;
+	flops_blas1 = 0;
+
+	// start timer
+	double timespent = -omp_get_wtime();
+
+	// main timeloop
+	double alpha = options.alpha;
+	double tolerance = 1.e-6;
+	for (int timestep = 1; timestep <= nt; timestep++)
+	{
+		// set x_new and x_old to be the solution
+		ss_copy(x_old, x_new, N);
+
+		double residual;
+		bool converged = false;
+		int it = 1;
+		for ( ; it <= 50; it++)
+		{
+			// compute residual : requires both x_new and x_old
+			diffusion(x_new, b);
+			residual = ss_norm2(b, N);
+
+			// check for convergence
+			if (residual < tolerance)
+			{
+				converged = true;
+				break;
+			}
+
+			// solve linear system to get -deltax
+			bool cg_converged = false;
+			ss_cg(deltax, b, 200, tolerance, &cg_converged);
+
+			// check that the CG solver converged
+			if (!cg_converged) break;
+
+			// update solution
+			ss_axpy(x_new, -1.0, deltax, N);
+		}
+
+		// output some statistics
+		if (converged)
+			printf("step %d required %d iterations for residual %E\n", timestep, it, residual);
+		else
+		{
+			fprintf(stderr, "step %d ERROR : nonlinear iterations failed to converge\n", timestep);
+			break;
+		}
+	}
+
+	// get times
+	timespent += omp_get_wtime();
+	unsigned long long flops_total = flops_diff + flops_blas1;
+
+	////////////////////////////////////////////////////////////////////
+	// write final solution to BOV file for visualization
+	////////////////////////////////////////////////////////////////////
+
+	// binary data
+	{
+		FILE* output = fopen("output.bin", "w");
+		fwrite(x_new, sizeof(double), nx * ny, output);
+		fclose(output);
+	}
+
+	// metadata
+	{
+		FILE* output = fopen("output.bov", "w");
+		fprintf(output, "TIME: 0.0\n");
+		fprintf(output, "DATA_FILE: output.bin\n");
+		fprintf(output, "DATA_SIZE: %d, %d, 1\n", nx, ny);
+		fprintf(output, "DATA_FORMAT: DOUBLE\n");
+		fprintf(output, "VARIABLE: phi\n");
+		fprintf(output, "DATA_ENDIAN: LITTLE\n");
+		fprintf(output, "CENTERING: nodal\n");
+		fprintf(output, "BYTE_OFFSET: 4\n");
+		fprintf(output, "BRICK_SIZE: 1.0 %f 1.0\n", (ny - 1) * options.dx);
+		fclose(output);
+	}
+
+	// print table sumarizing results
+	printf("--------------------------------------------------------------------------------\n");
+	printf("simulation took %f seconds\n", timespent);
+	printf("                %llu floating point operations\n", flops_total);
+	printf("                %f GFLOPs\n", flops_total / timespent / 1e9);
+	printf("--------------------------------------------------------------------------------\n");
+
+	// deallocate global fields
+	delete[] x_new;
+	delete[] x_old;
+	delete[] bndN;
+	delete[] bndS;
+	delete[] bndE;
+	delete[] bndW;
+
+	printf("Goodbye!\n");
+
+	return 0;
+}
+

--- a/cxx/makefile
+++ b/cxx/makefile
@@ -1,0 +1,22 @@
+CXX = g++
+CXXFLAGS = -O3 -mtune=native -ffast-math -g -fopenmp
+
+SOURCES = stats.cpp data.cpp operators.cpp linalg.cpp
+HEADERS = stats.h   data.h   operators.h   linalg.h
+OBJ     = stats.o   data.o   operators.o   linalg.o
+
+.SUFFIXES: .cpp
+
+all: main
+
+.cpp.o: $< $(HEADERS)
+	$(CXX) $(CXXFLAGS) $(IFLAGS) -c $< -o $@
+
+main: $(OBJ) main.cpp $(HEADERS)
+	$(CXX) $(CXXFLAGS) *.o main.cpp  -o $@
+
+clean:
+	rm -f main
+	rm -f *.o
+	rm -f *.i
+

--- a/cxx/operators.cpp
+++ b/cxx/operators.cpp
@@ -1,0 +1,142 @@
+//******************************************
+// operators.f90
+// based on min-app code written by Oliver Fuhrer, MeteoSwiss
+// modified by Ben Cumming, CSCS
+// *****************************************
+
+// Description: Contains simple operators which can be used on 3d-meshes
+
+#include "data.h"
+#include "operators.h"
+#include "stats.h"
+
+using namespace operators;
+
+void operators::diffusion(const double* up, double* sp)
+{
+	data::discretization_t& options = data::options;
+	
+	double (*u)[options.nx] = (double(*)[options.nx])up;
+	double (*s)[options.nx] = (double(*)[options.nx])sp;
+
+	double (*x_old)[options.nx] = (double(*)[options.nx])data::x_old;
+	double *bndE = data::bndE, *bndW = data::bndW;
+	double *bndN = data::bndN, *bndS = data::bndS;
+
+	double dxs = 1000. * (options.dx * options.dx);
+	double alpha = options.alpha;
+	int iend  = options.nx - 1;
+	int jend  = options.ny - 1;
+
+	// the interior grid points
+	for (int j = 1; j < jend; j++)
+		for (int i = 1; i < iend; i++)
+		{
+			s[j][i] = -(4. + alpha) * u[j][i]               // central point
+			                        + u[j][i-1] + u[j][i+1] // east and west
+			                        + u[j-1][i] + u[j+1][i] // north and south
+
+			                        + alpha * x_old[j][i]
+			                        + dxs * u[j][i] * (1.0 - u[j][i]);
+                }
+
+	// the east boundary
+	{
+		int i = options.nx - 1;
+		for (int j = 1; j < jend; j++)
+		{
+			s[j][i] = -(4. + alpha) * u[j][i]
+						+ u[j][i-1] + u[j-1][i] + u[j+1][i]
+						
+						+ alpha*x_old[j][i] + bndE[j]
+						+ dxs * u[j][i] * (1.0 - u[j][i]);
+		}
+	}
+	
+	// the west boundary
+	{
+		int i = 0;
+		for (int j = 1; j < jend; j++)
+		{
+			s[j][i] = -(4. + alpha) * u[j][i]
+						+ u[j][i+1] + u[j-1][i] + u[j+1][i]
+						
+						+ alpha * x_old[j][i] + bndW[j]
+						+ dxs * u[j][i] * (1.0 - u[j][i]);
+		}
+	}
+
+	// the north boundary (plus NE and NW corners)
+	{
+		int j = options.ny - 1;
+		
+		{
+			int i = 0; // NW corner
+			s[j][i] = -(4. + alpha) * u[j][i]
+						+ u[j][i+1] + u[j-1][i]
+						
+						+ alpha * x_old[j][i] + bndW[j] + bndN[i]
+						+ dxs * u[j][i] * (1.0 - u[j][i]);
+		}
+
+		// north boundary
+		for (int i = 1; i < iend; i++)
+		{
+			s[j][i] = -(4. + alpha) * u[j][i]
+						+ u[j][i-1] + u[j][i+1] + u[j-1][i]
+						
+						+ alpha*x_old[j][i] + bndN[i]
+						+ dxs * u[j][i] * (1.0 - u[j][i]);
+		}
+
+		{
+			int i = options.nx; // NE corner
+			s[j][i] = -(4. + alpha) * u[j][i]
+						+ u[j][i-1] + u[j-1][i]
+						
+						+ alpha * x_old[j][i] + bndE[j] + bndN[i]
+						+ dxs * u[j][i] * (1.0 - u[j][i]);
+		}
+	}
+
+	// the south boundary
+	{
+		int j = 0;
+		
+		{
+			int i = 0; // SW corner
+			s[j][i] = -(4. + alpha) * u[j][i]
+						+ u[j][i+1] + u[j+1][i]
+						
+						+ alpha * x_old[j][i] + bndW[j] + bndS[i]
+						+ dxs * u[j][i] * (1.0 - u[j][i]);
+		}
+
+		// south boundary
+		for (int i = 1; i < iend; i++)
+		{
+			s[j][i] = -(4. + alpha) * u[j][i]
+						+ u[j][i-1] + u[j][i+1] + u[j+1][i]
+						
+						+ alpha * x_old[j][i] + bndS[i]
+						+ dxs * u[j][i] * (1.0 - u[j][i]);
+		}
+		
+		{
+			int i = options.nx - 1; // SE corner
+			s[j][i] = -(4. + alpha) * u[j][i]
+						+ u[j][i-1] + u[j+1][i]
+						
+						+ alpha * x_old[j][i] + bndE[j] + bndS[i]
+						+ dxs * u[j][i] * (1.0 - u[j][i]);
+		}
+	}
+
+	// Accumulate the flop counts
+	// 8 ops total per point
+	stats::flops_diff +=
+		+ 12 * (options.nx - 2) * (options.ny - 2) // interior points
+		+ 11 * (options.nx - 2  +  options.ny - 2) // NESW boundary points
+		+ 11 * 4;                                  // corner points
+}
+

--- a/cxx/operators.h
+++ b/cxx/operators.h
@@ -1,0 +1,18 @@
+//******************************************
+// operators.f90
+// based on min-app code written by Oliver Fuhrer, MeteoSwiss
+// modified by Ben Cumming, CSCS
+// *****************************************
+
+// Description: Contains simple operators which can be used on 3d-meshes
+
+#ifndef OPERATORS_H
+#define OPERATORS_H
+
+namespace operators
+{
+	void diffusion(const double* up, double* sp);
+}
+
+#endif // OPERATORS_H
+

--- a/cxx/stats.cpp
+++ b/cxx/stats.cpp
@@ -1,0 +1,4 @@
+#include "stats.h"
+
+unsigned long long stats::flops_diff, stats::flops_bc, stats::flops_blas1;
+

--- a/cxx/stats.h
+++ b/cxx/stats.h
@@ -1,0 +1,10 @@
+#ifndef STATS_H
+#define STATS_H
+
+namespace stats
+{
+	extern unsigned long long flops_diff, flops_bc, flops_blas1;
+}
+
+#endif // STATS_H
+


### PR DESCRIPTION
Hi,

As per our discussion last Friday, we would like to create a reference CUDA version w/o libraries. I asked whether that should be CUDA C or CUDA Fortran, and the answer was CUDA C. Okay, in this case I'd like to start with creating C++ variant of program, that later could be used to create CUDA version. C++ implementation closely mimics Fortran: modules -> namespaces, (i,j) -> [j][i], array zeroing -> memset, etc. I compared results for "128 128 10000 1" - they are not identical, but very similar.
