### PR TITLE
Use MPI functions to create a cartesian topology.

### DIFF
--- a/mpi/cxx/data.cpp
+++ b/mpi/cxx/data.cpp
@@ -73,7 +73,6 @@ void SubDomain::init(int mpi_rank, int mpi_size, Discretization& discretization)
 
     rank = mpi_rank;
     size = mpi_size;
-    // TODO: should we use comm_cart instead of MPI_COMM_WORLD for the communications?
 }
 
 // print domain decomposition information to stdout

--- a/mpi/cxx/data.cpp
+++ b/mpi/cxx/data.cpp
@@ -31,16 +31,27 @@ SubDomain      domain;
 void SubDomain::init(int mpi_rank, int mpi_size, Discretization& discretization)
 {
     // determine the number of subdomains in the x and y dimensions
-    ndomx = sqrt(double(mpi_size));
-    while( mpi_size%ndomx )
-        ndomx--;
-    ndomy = mpi_size / ndomx;
+    int dims[2] = { 0, 0 };
+    MPI_Dims_create(mpi_size, 2, dims);
+    ndomy = dims[0];
+    ndomx = dims[1];
 
-    // compute this sub-domain index
-    // work backwards from: mpi_rank = (domx-1) + (domy-1)*ndomx
-    domx = mpi_rank % ndomx + 1;
-    domy = (mpi_rank-domx+1) / ndomx + 1;
+    // create a 2D non-periodic cartesian topology
+    int periods[2] = { 0, 0 };
+    MPI_Comm comm_cart;
+    MPI_Cart_create(MPI_COMM_WORLD, 2, dims, periods, 0, &comm_cart);
 
+    // retrieve coordinates of the rank in the topology
+    int coords[2];
+    MPI_Cart_coords(comm_cart, mpi_rank, 2, coords);
+    domy = coords[0]+1;
+    domx = coords[1]+1;
+
+    // set neighbours for all directions
+    MPI_Cart_shift(comm_cart, 0, 1, &neighbour_south, &neighbour_north);
+    MPI_Cart_shift(comm_cart, 1, 1, &neighbour_west, &neighbour_east);
+
+    // get bounding box
     nx = discretization.nx / ndomx;
     ny = discretization.ny / ndomy;
     // TODO: the startx and endx values might have to be adjusted by 1
@@ -60,26 +71,9 @@ void SubDomain::init(int mpi_rank, int mpi_size, Discretization& discretization)
     // get total number of grid points in this sub-domain
     N = nx*ny;
 
-    neighbour_east  = mpi_rank+1;
-    neighbour_west  = mpi_rank-1;
-    neighbour_north = mpi_rank+ndomx;
-    neighbour_south = mpi_rank-ndomx;
-
-    if (domx == 1) {
-        neighbour_west = -1;
-    }
-    if (domx == ndomx) {
-        neighbour_east = -1;
-    }
-    if (domy == 1) {
-        neighbour_south = -1;
-    }
-    if (domy == ndomy) {
-        neighbour_north = -1;
-    }
-
     rank = mpi_rank;
     size = mpi_size;
+    // TODO: should we use comm_cart instead of MPI_COMM_WORLD for the communications?
 }
 
 // print domain decomposition information to stdout


### PR DESCRIPTION
There is one question pending, MPI will create a communicator for the Cartesian topology.
It is not required to use it because we are just interested in the neighbours value and we will not change the topology. However, will it not be better for learning purposes to use it?
This commit does not use the created communicator.